### PR TITLE
Fix, avoid ending up with the wrong merged head values for each token

### DIFF
--- a/transformer.py
+++ b/transformer.py
@@ -90,6 +90,7 @@ class MultiHeadAttention(nn.Module):
         qkv = qkv.permute(0, 2, 1, 3)
         q, k, v = qkv.chunk(3, dim=-1)
         values, attention = scaled_dot_product(q, k, v, mask)
+        values = values.permute(0, 2, 1, 3)
         values = values.reshape(batch_size, sequence_length, self.num_heads * self.head_dim)
         out = self.linear_layer(values)
         return out


### PR DESCRIPTION
(originally added as a comment to your youtube video, minor edits here)

Hi! Great series. About the problem with empty text evaluation, I'm not sure about this, but you can try to revert the permutation of dimensions 1 and 2 before reshaping values, at transformer.py:93.
```
        values, attention = scaled_dot_product(q, k, v, mask)  # value.shape: (B, 8, 200, 64)
        values = values.permute(0, 2, 1, 3)                                # <--- insert this
        values = values.reshape(batch_size, sequence_length, self.num_heads * self.head_dim) # reshaping to (B, 200, 8 * 64)
```

We need to switch dim 1 & 2, to avoid ending up with the wrong merged head values for each token. E.g., given this code:
```
        before, attention = scaled_dot_product(q, k, v, mask)  # before.shape: (B, 8, 200, 64)
        after = before.reshape(batch_size, sequence_length, self.num_heads * self.head_dim) # reshaping to (B, 200, 8 * 64)
```
Without permute(), then the values **'after[B,0,:]'**, which should be the merged heads for token 0, would be the values from **'before[B,0,0:8,:]'**, which would be the _first head_ from the 8 first tokens. I´m unsure, but if I am right (I´m still a beginner), that sounds wrong :P

The training result is different, but I don't know if it is correct.

Anyway, thanks for your great ml videos. Always fun watching your content.

Result:
---
Epoch 6
Iteration 0 : 1.5735915899276733
English: hes a scientist.
Kannada Translation: ಇವರು ಸಂಶೋಧಕ ಸ್ವಭಾವದವರು.
Kannada Prediction: ಇವರು ನಂಬ್ಧಿ್ಮಾಥಾವಗಿ ಾೆ.
Evaluation translation (('should we go to the mall?',)?) : ('ಈಗಾಗಲೇ ಅವರು ಹೇಗೆ ಹೇಗೆ?<END>',)

(feel free to close/delete this pr, I created this due to youtube seemingly blocked my comment there)